### PR TITLE
Add button to copy hex color

### DIFF
--- a/BetterColorPicker.KKS/BetterColorPicker.KKS.csproj
+++ b/BetterColorPicker.KKS/BetterColorPicker.KKS.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro" Version="2019.4.9" />
     <PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.ImageConversionModule" Version="2019.4.9" />
+    <PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule" Version="2019.4.9" />
     <PackageReference Include="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" Version="2019.4.9" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.25.0">
       <PrivateAssets>runtime</PrivateAssets>

--- a/Shared/BetterColorPicker.cs
+++ b/Shared/BetterColorPicker.cs
@@ -149,6 +149,26 @@ namespace BetterColorPicker
 
             __instance.updateColorAction += UpdateTextboxHexText;
 
+            var copyBtn = Instantiate(originalBtn, __instance.transform.Find("ColorMode"), false);
+            copyBtn.name = "CopyHexButton";
+
+
+            var copyBtnRt = copyBtn.GetComponent<RectTransform>();
+            copyBtnRt.localPosition = new Vector3(130, -24, 0);
+            copyBtnRt.sizeDelta = new Vector2(65, 28);
+
+            copyBtnRt.GetComponentInChildren<TextMeshProUGUI>().text = "Copy";
+
+            var copyB = copyBtn.GetComponent<Button>();
+            copyB.onClick.RemoveAllListeners();
+            copyB.onClick.AddListener(() =>
+            {
+                if(Input.GetKey(KeyCode.LeftShift))
+                    GUIUtility.systemCopyBuffer = textbox.text.Trim('#');
+                else
+                    GUIUtility.systemCopyBuffer = textbox.text.Substring(1, textbox.text.Length - 3);
+            });
+
             // Probably unnecessary, but just in case
             UpdateTextboxHexText(__instance.color);
 


### PR DESCRIPTION
Adds a button to easily copy the current hex code. It's copied without the hashtag and alpha part by default, Since most other programs don't like either of these two. By pressing shift you can also keep the alpha part.
![image](https://github.com/user-attachments/assets/8645de1e-64b7-4d15-91c7-17dc11b8f08d)
![image](https://github.com/user-attachments/assets/6448450a-2147-4077-ae41-843d81a3a6ec)


IMGUIModule is added to KKS for `GUIUtility` to copy text to the clipboard.